### PR TITLE
Properly referencing HedgeLib as a SubModule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "Sonic06Randomiser/HedgeLib"]
+	path = Sonic06Randomiser/HedgeLib
+	url = https://github.com/Radfordhound/HedgeLib
+[submodule "HedgeLib"]
+	path = HedgeLib
+	url = https://github.com/Radfordhound/HedgeLib

--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 A tool designed to randomise various elements of the Set Object Layout Data in SONIC THE HEDGEHOG (2006) on the Xbox 360 and Playstation 3.
 
 # Building
-The build process for this is currently a tad clunky both due to me not knowing how to propely make HedgeLib a dependancy and due to the S06SetData class in HedgeLib being broken. Therefore, when building the randomiser, you need to manually fix the HedgeLib DLL.
-
-1) Clone this repository to a folder on your computer & clone the DirectX version of [Radfordhound's](https://github.com/Radfordhound) [HedgeLib](https://github.com/Radfordhound/HedgeLib/tree/directX) repository to a different folder.
-2) Open the HedgeLib.sln file in Visual Studio and open HedgeLib/Sets/SetData.cs. Scroll down to Line 91 & replace "var template = (objectTemplates.ContainsKey(obj.ObjectType)) ?" with: "var template = (objectTemplates != null && objectTemplates.ContainsKey(obj.ObjectType)) ?". Then compile the HedgeLib project to obtain a DLL in HedgeLib/bin/Debug.
-3) Open the Sonic06Randomiser.sln file in Visual Studio; right click on References and choose Add Reference. Click browse then navigate to and select the HedgeLib.dll, then click OK.
-4) Build the program like you would any other C# application.
+1) Clone this repository into a folder of your choice using the Git CMD tool with this command: `git clone --recurse-submodules https://github.com/Knuxfan24/SONIC-THE-HEDGEHOG-2006-Randomiser -b submodule-test`
+2) Open HedgeLib.sln in Visual Studio and build the HedgeLib project in it, this will create a DLL in `..\HedgeLib\HedgeLib\bin\Debug`.
+3) Open Sonic06Randomiser.sln in Visual Studio and run the program to build and run a binary, located in `..\Sonic06Randomiser\bin\Debug`
 
 # Usage
 1) In order to use the randomiser, you need to extract the scripts.arc file that contains all of the Sonic 06 set data files. I recommend using Hyper's [Sonic '06 Toolkit](https://gamebanana.com/tools/6576) application for this purpose.

--- a/Sonic06Randomiser/Sonic06Randomiser.csproj
+++ b/Sonic06Randomiser/Sonic06Randomiser.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="HedgeLib">
+      <HintPath>..\HedgeLib\HedgeLib\bin\Debug\HedgeLib.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Thanks to SuperSonic16 for updating the HedgeLib code and committing it to Rad's repo.